### PR TITLE
Redirect to new domain

### DIFF
--- a/aframe-lab/index.html
+++ b/aframe-lab/index.html
@@ -27,6 +27,9 @@
 		
 		<link rel="stylesheet" href="https://dandykong.github.io/styles/main.css" />
 		
+		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/aframe-lab/">
+		<link rel="canonical" href="https://www.dandykong.com/aframe-lab/">
+		
 		<script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
 		<script src="https://cdn.jsdelivr.net/gh/donmccurdy/aframe-extras@v6.1.1/dist/aframe-extras.min.js"></script>
 		<script src="https://unpkg.com/aframe-environment-component@1.3.1/dist/aframe-environment-component.min.js"></script>

--- a/blog/2022/07/01/pardon-my-dust/index.html
+++ b/blog/2022/07/01/pardon-my-dust/index.html
@@ -28,24 +28,10 @@
 		<meta name="twitter:site" content="@dandykong1" />
 		<meta name="twitter:creator" content="@dandykong1" />
 		
-		<script type="application/ld+json">
-		{
-			"@context": "https://schema.org",
-			"@type": "NewsArticle",
-			"headline": "Pardon My Dust",
-			"image": "https://dandykong.github.io/blog/2022/07/01/pardon-my-dust/img/pexels-picjumbocom-196655.jpg",
-			"datePublished": "2022-07-01T13:12:00-05:00",
-			"dateModified": "2022-07-01T14:19:27-05:00",
-			"author": {
-				"@type": "Person",
-				"name": "Daniel Harrison",
-				"url": "https://dandykong.github.io/"
-			}
-		}
-		</script>
-		
 		<link rel="stylesheet" href="https://dandykong.github.io/styles/main.css" />
 		<script type="text/javascript" src="https://dandykong.github.io/js/includeHTML.js"></script>
+		
+		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/">
 	</head>
 	<body>
 		<div id="navbar" w3-include-html="https://dandykong.github.io/views/nav.html"></div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -27,6 +27,8 @@
 		
 		<link rel="stylesheet" href="https://dandykong.github.io/styles/main.css" />
 		<script type="text/javascript" src="https://dandykong.github.io/js/includeHTML.js"></script>
+		
+		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/">
 	</head>
 	<body>
 		<div id="navbar" w3-include-html="https://dandykong.github.io/views/nav.html"></div>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
 		
 		<link rel="stylesheet" href="styles/main.css" />
 		<script type="text/javascript" src="js/includeHTML.js"></script>
+		
+		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/">
+		<link rel="canonical" href="https://www.dandykong.com/">
 	</head>
 	<body>
 		<div id="navbar" w3-include-html="views/nav.html"></div>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -28,6 +28,9 @@
 		
 		<link rel="stylesheet" href="https://dandykong.github.io/styles/main.css" />
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/dandykong/dandykong.github.io@main/js/includeHTML.js"></script>
+		
+		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/">
+		<link rel="canonical" href="https://www.dandykong.com/">
 	</head>
 	<body>
 		<div id="navbar" w3-include-html="https://dandykong.github.io/views/nav.html"></div>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -29,8 +29,8 @@
 		<link rel="stylesheet" href="https://dandykong.github.io/styles/main.css" />
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/gh/dandykong/dandykong.github.io@main/js/includeHTML.js"></script>
 		
-		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/">
-		<link rel="canonical" href="https://www.dandykong.com/">
+		<meta http-equiv="refresh" content="0; URL=https://www.dandykong.com/portfolio/">
+		<link rel="canonical" href="https://www.dandykong.com/portfolio/">
 	</head>
 	<body>
 		<div id="navbar" w3-include-html="https://dandykong.github.io/views/nav.html"></div>


### PR DESCRIPTION
Redirect from Github Pages to the new domain, preserving assets and CSS. Branched in order to prevent excessive autodeploys while I edit files.